### PR TITLE
Dependancies have changed for the FieldManager

### DIFF
--- a/src/Settings/Panel.php
+++ b/src/Settings/Panel.php
@@ -60,7 +60,7 @@ class Panel
      */
     public function __construct($key, $settings = [])
     {
-        $this->fieldManager = new FieldManager();
+        $this->fieldManager = \App::make('LaravelFlare\Fields\FieldManager');
 
         $this->setupPanel($key, $settings);
     }


### PR DESCRIPTION
LaravelFlare\Fields\FieldManager now has dependancies, so can't just be created using new - this uses the IoC instead.
